### PR TITLE
Fix redirect links

### DIFF
--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,12 +1,12 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the equivalent second edition page][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [The equivalent page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/associated-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-03-advanced-traits.html#associated-types

--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,11 +1,11 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the equivalent second edition page][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [The equivalent page in the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/associated-types.html

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/borrow-and-asref.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-00-smart-pointers.html

--- a/redirects/choosing-your-guarantees.md
+++ b/redirects/choosing-your-guarantees.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/choosing-your-guarantees.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-00-smart-pointers.html 

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/closures.html
-[2]: second-edition/index.html
+[2]: second-edition/ch13-01-closures.html

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/comments.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-04-comments.html

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/concurrency.html
-[2]: second-edition/index.html
+[2]: second-edition/ch16-00-concurrency.html

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/const-and-static.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html#accessing-or-modifying-a-mutable-static-variable

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -5,8 +5,11 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter about modules in the second edition of The Rust Programming Language][2]
+
+* [Related chapter about crates in the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/crates-and-modules.html
-[2]: second-edition/index.html
+[2]: second-edition/ch07-00-modules.html
+[3]: second-edition/ch14-00-more-about-cargo.html

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/deref-coercions.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/documentation.html
-[2]: second-edition/index.html
+[2]: second-edition/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/drop.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-03-drop.html

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/enums.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-01-defining-an-enum.html

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/error-handling.html
-[2]: second-edition/index.html
+[2]: second-edition/ch09-00-error-handling.html

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/ffi.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/functions.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-03-how-functions-work.html

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -5,8 +5,9 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/generics.html
-[2]: second-edition/index.html
+[2]: second-edition/ch10-00-generics.html
+

--- a/redirects/getting-started.md
+++ b/redirects/getting-started.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/getting-started.html
-[2]: second-edition/index.html
+[2]: second-edition/ch01-00-introduction.html

--- a/redirects/guessing-game.md
+++ b/redirects/guessing-game.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/guessing-game.html
-[2]: second-edition/index.html
+[2]: second-edition/ch02-00-guessing-game-tutorial.html

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/if-let.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-03-if-let.html

--- a/redirects/if.md
+++ b/redirects/if.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/if.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-05-control-flow.html#if-expressions

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/iterators.html
-[2]: second-edition/index.html
+[2]: second-edition/ch13-02-iterators.html

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -5,8 +5,11 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
+
+* [Related page in the second edition of The Rust Programming Language (covering more advanced topics)][3]
 
 
 [1]: first-edition/lifetimes.html
-[2]: second-edition/index.html
+[2]: second-edition/ch10-03-lifetime-syntax.html
+[3]: second-edition/ch19-02-advanced-lifetimes.html

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/loops.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-05-control-flow.html#repetition-with-loops

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -5,8 +5,12 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in  the second edition of The Rust Programming Language][2]
+
+* [Related chapter in the second edition of The Rust Programming Language (covering more advanced topics)][3]
 
 
 [1]: first-edition/match.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-02-match.html
+[3]: second-edition/ch18-00-patterns.html
+

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/method-syntax.html
-[2]: second-edition/index.html
+[2]: second-edition/ch05-03-method-syntax.html

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/mutability.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-01-variables-and-mutability.html

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/operators-and-overloading.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-03-advanced-traits.html#operator-overloading-and-default-type-parameters

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in  second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/ownership.html
-[2]: second-edition/index.html
+[2]: second-edition/ch04-00-understanding-ownership.html

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -5,8 +5,11 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
+
+* [Related page in the second edition of The Rust Programming Language (covering more advanced topics)][3]
 
 
 [1]: first-edition/patterns.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-02-match.html#patterns-that-bind-to-values
+[3]: second-edition/ch18-03-pattern-syntax.html

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/primitive-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-02-data-types.html

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -8,5 +8,6 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 * [Index of the second edition of The Rust Programming Language][2]
 
 
+
 [1]: first-edition/procedural-macros.html
 [2]: second-edition/index.html

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/raw-pointers.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/references-and-borrowing.html
-[2]: second-edition/index.html
+[2]: second-edition/ch04-02-references-and-borrowing.html

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -5,8 +5,12 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in second edition of The Rust Programming Language][2]
+
+* [Related page in second edition of The Rust Programming Language  (covering more advanced topics)][3]
 
 
 [1]: first-edition/strings.html
-[2]: second-edition/index.html
+[2]: second-edition/ch04-03-slices.html#string-slices
+[3]: second-edition/ch08-02-strings.html
+

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/structs.html
-[2]: second-edition/index.html
+[2]: second-edition/ch05-00-structs.html

--- a/redirects/syntax-and-semantics.md
+++ b/redirects/syntax-and-semantics.md
@@ -5,8 +5,13 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in the second edition of The Rust Programming Language (covering Rust syntax in general)][2]
+* [Related page in the second edition of The Rust Programming Language (covering Rust keywords)][3]
+* [Related page in the second edition of The Rust Programming Language (covering Rust operators)][4]
 
 
 [1]: first-edition/syntax-and-semantics.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-00-common-programming-concepts.html
+[3]: second-edition/appendix-01-keywords.html
+[4]: second-edition/appendix-02-operators.html
+

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related chapter in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/testing.html
-[2]: second-edition/index.html
+[2]: second-edition/ch11-00-testing.html

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/trait-objects.html
-[2]: second-edition/index.html
+[2]: second-edition/ch17-02-trait-objects.html

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -5,8 +5,11 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
+
+* [Related page in the second edition of The Rust Programming Language (covering more advanced topics)][3]
 
 
 [1]: first-edition/traits.html
-[2]: second-edition/index.html
+[2]: second-edition/ch10-02-traits.html
+[3]: second-edition/ch19-03-advanced-traits.html

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -5,8 +5,9 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/type-aliases.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-04-advanced-types.html#type-aliases-create-type-synonyms
+

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/unsafe.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -5,8 +5,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related section in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/unsized-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-04-advanced-types.html#dynamically-sized-types--sized

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -5,8 +5,9 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/vectors.html
-[2]: second-edition/index.html
+[2]: second-edition/ch08-01-vectors.html
+


### PR DESCRIPTION
> I Google Rust concepts a lot, and almost always end up at the redirect page, which almost always points me at the index of the Second Edition instead of the thing I Googled for. I'd love if the link pointed to the correct section to save me lots of clicking and scanning time.
> 
> This is a "test PR," if you will, to see what y'all think of doing this in general before I invest the time to do other pages.

> I figure the page should help people when it can, and when it can't, just do our best :)

Couldn't agree more.  This commit adds links to chapter, page or section of the second edition where appropriate. Of the 57 redirect pages I managed to find suitable links for 41 of them. 
For details how the assignment was done, see the commit message.

Actually carrying out the mapping will hopefully make it easier to convince the reviewers.

 
